### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ To update the publication each quarter, the analyst responsible for updating the
 
 Once this is done, the raw data files and Excel tables for the publication have been produced. The final step is knitting the RMarkdown documents:
 
-- In the _RMarkdown_ sub-folder inside the _Master_ folder, open both `.Rmd` scripts and click _Knit_
+- In the _RMarkdown_ sub-folder inside the _Master_ folder, run the `markdown_report_charts.R` and `markdown_tables.R` scripts
+- Check the output of both
+- Open both `.Rmd` scripts and click _Knit_
 - Check output
 - A couple of manual steps are required to finish off the markdown documents (adding cover page, table of contents and formatting tables correctly). They are outlined in the README of the [National Statistics Publication Templates repository](https://github.com/NHS-NSS-transforming-publications/National-Stats-Template).


### PR DESCRIPTION
Hi guys,

As promised, I added some instructions to the readme about running the publication. I mostly lifted it from the [HSMR one](https://github.com/NHS-NSS-transforming-publications/hsmr).

I don't think it's a finished article (particularly towards the end); there are steps you guys take that I don't know the specifics of (like refreshing the Excel tables) and no doubt there are some that I'm completely unaware of. I'd suggest you add instructions on those bits (and add extra detail to the bits I put in if need be) yourselves. I'll fix any glaring errors/typos though, so let me know if you spot any.

Lastly (should have said this before, you were maybe going to do this anyway), when you're automating in-line bits of R code in the RMarkdown scripts (like `x` in the summary script), I'd write all the code in separate R scripts and source them into the RMarkdown scripts. It'll make them a little less cluttered. I'd also create an _archive_ sub-folder inside the _RMarkdown_ folder to save old copies of the `.Rmd` scripts, to stop the main folder from getting too cluttered. Although once you automate all the inline bits those scripts probably won't change much, so it'd maybe be easier to just keep the names of them the same for every publication and change the names of the word documents after they've been knitted instead.

Cheers,

Jack